### PR TITLE
compact list to remove nulls

### DIFF
--- a/aws/aurora/main.tf
+++ b/aws/aurora/main.tf
@@ -44,7 +44,7 @@ locals {
     }
   ]
 
-  security_group_rules = [local.access_cidr_rules, local.access_sg_rules]
+  security_group_rules = compact([local.access_cidr_rules, local.access_sg_rules])
 }
 
 resource "aws_db_subnet_group" "db" {


### PR DESCRIPTION
fix to correct apply [errors](https://us-gov-east-1.console.amazonaws-us-gov.com/codesuite/codebuild/026536877604/projects/aft-account-customizations-terraform/build/aft-account-customizations-terraform%3Aff30efa1-f9cd-4c10-85f1-c58e0a2fa1e4?region=us-gov-east-1) I'm running into when only defining accss_sg_ids and not access_cidrs. 

module [used](https://github.com/Lifebit-Fedramp/aft-account-customizations/blob/main/shared/terraform/jiradc_aurora.tf) 

```
Error: Attempt to get attribute from null value

  on .terraform/modules/jiradc_aurora/aws/aurora/main.tf line 121, in resource "aws_security_group" "aurora":
 121:       from_port       = ingress.value.from_port
    ├────────────────
    │ ingress.value is null

This value is null, so it does not have any attributes.

Error: Attempt to get attribute from null value

  on .terraform/modules/jiradc_aurora/aws/aurora/main.tf line 122, in resource "aws_security_group" "aurora":
 122:       to_port         = ingress.value.to_port
    ├────────────────
    │ ingress.value is null

This value is null, so it does not have any attributes.

Error: Attempt to get attribute from null value

  on .terraform/modules/jiradc_aurora/aws/aurora/main.tf line 123, in resource "aws_security_group" "aurora":
 123:       protocol        = ingress.value.protocol
    ├────────────────
    │ ingress.value is null

This value is null, so it does not have any attributes.

Error: Attempt to get attribute from null value

  on .terraform/modules/jiradc_aurora/aws/aurora/main.tf line 124, in resource "aws_security_group" "aurora":
 124:       cidr_blocks     = ingress.value.cidr_blocks
    ├────────────────
    │ ingress.value is null

This value is null, so it does not have any attributes.

Error: Attempt to get attribute from null value

  on .terraform/modules/jiradc_aurora/aws/aurora/main.tf line 125, in resource "aws_security_group" "aurora":
 125:       self            = ingress.value.self
    ├────────────────
    │ ingress.value is null

This value is null, so it does not have any attributes.

Error: Attempt to get attribute from null value

  on .terraform/modules/jiradc_aurora/aws/aurora/main.tf line 126, in resource "aws_security_group" "aurora":
 126:       security_groups = ingress.value.security_groups
    ├────────────────
    │ ingress.value is null

This value is null, so it does not have any attributes.
```